### PR TITLE
render-deploy-fix

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -195,11 +195,6 @@ SOCIALACCOUNT_QUERY_EMAIL = True
 
 SOCIALACCOUNT_PROVIDERS = {
     'google': {
-        "APP": {
-            "client_id": env("GOOGLE_CLIENT_ID"),
-            "secret": env("GOOGLE_SECRET_KEY"),
-            "key": "",
-        },
         'SCOPE': [
             'profile',
             'email',


### PR DESCRIPTION
Removed the google 'APP' dict from settings.SOCIALACCOUNT_PROVIDERS because this caused render deploy to fail.