### PR TITLE
can now add attendees to activities

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,7 +558,8 @@ POST /new/activity/
 		"location": "Uptown Bowling",
     "start_time": "2023-02-24T06:14:53.955425Z",
     "end_time": "2023-02-24T09:14:53.955425Z",
-		"total_votes": 0
+		"total_votes": 0,
+		"attendees": []
   }
 }
 ```
@@ -570,7 +571,7 @@ POST /new/activity/
 Requires authentication
 
 ```txt
-POST /activity/<activity_id>
+PATCH /activity/<activity_id>
 ```
 
 ```json
@@ -592,7 +593,44 @@ POST /activity/<activity_id>
     "description": "You must use your left hand to bowl!",
     "start_time": "2023-02-24T06:14:53.955425Z",
     "end_time": "2023-02-24T09:14:53.955425Z",
-		"total_votes": 0
+		"total_votes": 0,
+		"attendees": []
+  }
+}
+
+```
+
+## Add attendee to activity
+
+### request
+
+Requires authentication, username passed in request body
+
+```txt
+PATCH /activity/<activity_id>
+```
+
+```json
+{
+  "username": "bobuser"
+}
+```
+
+### response
+
+```json
+200 OK
+
+{
+  "activity": {
+    "id": 3,
+    "title": "Bowling night!",
+		"creator": "jcox",
+    "description": "You must use your left hand to bowl!",
+    "start_time": "2023-02-24T06:14:53.955425Z",
+    "end_time": "2023-02-24T09:14:53.955425Z",
+		"total_votes": 0,
+		"attendees": ["bobuser"]
   }
 }
 ```

--- a/congregate/serializers.py
+++ b/congregate/serializers.py
@@ -20,6 +20,7 @@ class ActivitySerializer(ModelSerializer):
     event = SlugRelatedField(slug_field='title', read_only=True)
     creator = SlugRelatedField(slug_field='username', read_only=True)
     total_votes = SerializerMethodField('get_votes_tally')
+    attendees = SlugRelatedField(slug_field='username', many=True, read_only=True)
 
     def get_votes_tally(self, obj):
         return obj.votes.aggregate(total_votes=Sum('vote'))['total_votes']
@@ -36,6 +37,7 @@ class ActivitySerializer(ModelSerializer):
             'start_time',
             'end_time',
             'total_votes',
+            'attendees',
         )
 
 
@@ -62,6 +64,7 @@ class EventSerializer(ModelSerializer):
         )
 
 
+# Is this necessary?
 class DecidedEventSerializer(ModelSerializer):
     group = SlugRelatedField(slug_field='title', read_only=True)
     activity_list = SerializerMethodField('get_activity_list')

--- a/congregate/urls.py
+++ b/congregate/urls.py
@@ -12,7 +12,6 @@ urlpatterns = [
     path('group/<int:group_id>', views.GroupHome.as_view(), name='group_home'),
     path('new/event/', views.CreateEvent.as_view(), name='new_event'),
     path('event/<int:event_id>', views.EventHome.as_view(), name='event_home'),
-    path('add-user-group/', views.add_user_group, name='add_user_group'),
     path('new/activity/', views.CreateActivity.as_view(), name='new_activity'),
     path('activity/<int:activity_id>', views.ActivityUpdate.as_view(), name='activity_update'),
     path('vote/<int:vote_id>', views.Voting.as_view(), name='vote'),

--- a/congregate/views.py
+++ b/congregate/views.py
@@ -307,6 +307,16 @@ class ActivityUpdate(RetrieveUpdateDestroyAPIView):
         queryset = Activity.objects.filter(id=self.kwargs['activity_id'])
         return queryset
 
+    def partial_update(self, request, *args, **kwargs):
+        activity = self.get_object()
+        if 'username' in request.data:
+            user = User.objects.get(username=request.data['username'])
+            activity.attendees.add(user)
+        serializer = self.get_serializer(activity, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        self.perform_update(serializer)
+        return Response(serializer.data)
+
 
 class Voting(UpdateAPIView):
     queryset = Vote.objects.all()


### PR DESCRIPTION
Now have ability to add attendees to activities.  Use same activity PATCH request for other activity updates but pass in the username of the prospective attendee. Tested locally via Insomnia. Documentation updated.